### PR TITLE
Update __init__.py → bug with outputs

### DIFF
--- a/isavailable/__init__.py
+++ b/isavailable/__init__.py
@@ -17,9 +17,9 @@ def isavailable(name: str) -> bool:
     url = f"https://pypi.org/project/{name}/"
     response = requests.get(url)
     if response.status_code == 404:
-        return True
-    elif response.status_code == 200:
         return False
+    elif response.status_code == 200:
+        return True
     else:
         typer.secho(
             f"An error occurred: {response.status_code}",


### PR DESCRIPTION
Hey @schneiderfelipe. I don't know if you noticed, but the isavailable outputs are switched. It is giving as available the unavailable packages and vice versa. I think the error is in the _isavailable_ function of _init_.py. (I made the change) Here is an example of what I am talking about:

![Screenshot from 2021-11-23 11-41-56](https://user-images.githubusercontent.com/60739184/143045053-8c31e9a2-e532-42da-bc10-70b6a5ce5250.png)

If you access [your](https://pypi.org/project/your/), it is available, but the package says it isn't. And you can see the same problem in [numpy](https://pypi.org/project/numpy/). And if you check  [whether](https://pypi.org/project/whether/) (as your example in the README file), it is not available, but the package says it is. 